### PR TITLE
Report generation: fix hardcoded paths & fix avatar carry-over bug

### DIFF
--- a/report.py
+++ b/report.py
@@ -161,6 +161,7 @@ table, th, td{{border: 1px solid black;}}
         # Reading elements of a message
         if any("channel_id" in s for s in data):
             for e in data:
+                avatar_path = ""
                 avatar = e["author"]["avatar"]
                 if avatar is not None:
                     if exists(join(output_dir, "Extracted", "Images", f"{avatar}.webp")):

--- a/report.py
+++ b/report.py
@@ -164,7 +164,7 @@ table, th, td{{border: 1px solid black;}}
                 avatar = e["author"]["avatar"]
                 if avatar is not None:
                     if exists(join(output_dir, "Extracted", "Images", f"{avatar}.webp")):
-                        avatar_path = join(output_dir, "Extracted", "Images", f"{avatar}.webp")
+                        avatar_path = join("..", "..", "Extracted", "Images", f"{avatar}.webp")
                 date = e["timestamp"].split("T", 1)[0]
                 time = e["timestamp"].split("T", 1)[1].split(".", 1)[0]
                 timestamp = date + " " + time
@@ -176,7 +176,7 @@ table, th, td{{border: 1px solid black;}}
                             att_file = key.filename
                             img_url = key.url
                             if exists(join(output_dir, "Extracted", "Images", att_file)):
-                                att_path = join(output_dir, "Extracted", "Images", att_file)
+                                att_path = join("..", "..", "Extracted", "Images", att_file)
                                 break
                 # Filling structure of a message with recovered data
                 message = f"""<table width="100%">


### PR DESCRIPTION
This PR includes fixes for two small bugs:

#### 1. Commit #b50362d 

When generating HTML reports, the full path to the files (such as avatars and attachments) are used - this works fine, until the folder is moved to a new location, then images don't load anymore. Commit #b50362d fixes this by switching to a relative path; "../../Extracted/Images/[...]".

#### 2. Commit #c8984bb

When generating HTML reports, while setting avatars the generator would try to look for an avatar like this: 
```
if avatar is not None:
    if exists(join(output_dir, "Extracted", "Images", f"{avatar}.webp")):
```
This works fine until the file it looks for does not exist, what happens then is it carries over the last avatar - using the previously set avatar for the previous message. This could lead to multiple users having the same avatar - when they could potentially have had different avatars.
Commit #c8984bb fixes this by setting `avatar_path` to empty at the beginning of the loop.

